### PR TITLE
Reverse Front of Robot/ArcadeDrive with RPM

### DIFF
--- a/src/robot.py
+++ b/src/robot.py
@@ -5,6 +5,7 @@ Main code for Robot
 
 import wpilib
 import robotmap
+import ctre
 from wpilib import Joystick
 from subsystems.drivetrain import DriveTrain as Drive
 from subsystems.grabber import Grabber
@@ -25,9 +26,6 @@ class Robot(wpilib.IterativeRobot):
         self.cStick = Joystick(self.kSticks['control'])
         self.drive = Drive(self)
         self.cubeGrabber = Grabber(self)
-        
-        # holds data from the FMS about the field elements.
-        self.fielddata = None
 
 
     def robotPeriodic(self):
@@ -43,37 +41,29 @@ class Robot(wpilib.IterativeRobot):
         """
         This function is run once each time the robot enters autonomous mode.
         """
-        # get field data -- currently removed until we add an IF statement
-        # self.fielddata = wpilib.DriverStation.getInstance().getGameSpecificMessage()
-        
-        self.drive.driveLeftMaster.setQuadraturePosition(0, 0)
-        self.drive.driveRightMaster.setQuadraturePosition(0, 0) 
+        # get field data
+        #self.fielddata = wpilib.DriverStation.getInstance().getGameSpecificMessage()        
 
     def autonomousPeriodic(self):
         """This function is called periodically during autonomous."""
-        
-        ## get field data
-        #if not self.fielddata:
-            #self.fielddata = wpilib.DriverStation.getInstance().getGameSpecificMessage()          
-            #nearswitch, scale, farswitch = list(self.fielddata)
-        
-        #if self.fielddata[0] == 'R':
-            #self.drive.arcade(.5, .2)
-        #else:
-            #self.drive.arcade(.5, -.2)
-            
-        self.drive.arcade(.5, 0)
+        #nearswitch, scale, farswitch = list(self.fielddata)
+#         
+#         if nearswitch == 'R':
+#             self.drive.arcade(.5, .2)
+#         else:
+#             self.drive.arcade(.5, -.2)
+        pass
 
     def teleopInit(self):
-        self.drive.driveLeftMaster.setQuadraturePosition(0, 0)
-        self.drive.driveRightMaster.setQuadraturePosition(0, 0)
+        pass
 
     def teleopPeriodic(self):
         """This function is called periodically during operator control."""
         speed = self.dStick.getY() * -1
         rotation = self.dStick.getTwist()
         # self.drive.moveSpeed(speed, speed)
-        self.drive.arcade(speed, rotation)
+        
+        self.drive.arcadeWithRPM(speed, rotation, 2800)
         
         self.cubeGrabber.grabberFunction()
 
@@ -81,6 +71,7 @@ class Robot(wpilib.IterativeRobot):
         pass
 
     def testPeriodic(self):
+        wpilib.LiveWindow.setEnabled(True)
         pass
 
 

--- a/src/subsystems/drivetrain.py
+++ b/src/subsystems/drivetrain.py
@@ -114,6 +114,10 @@ class DriveTrain(Subsystem):
             self.drive.arcadeDrive(-speed, rotation, True)
             
     def arcadeWithRPM(self, speed, rotation, maxRPM):
+        
+        if self.robot.dStick.getRawButtonReleased(3):
+            self.robotFrontToggleCount += 1
+            
         self.driveLeftMaster.setSafetyEnabled(False)
         
         XSpeed = wpilib.RobotDrive.limit(speed)
@@ -121,6 +125,10 @@ class DriveTrain(Subsystem):
 
         ZRotation = wpilib.RobotDrive.limit(rotation)
         ZRotation = self.applyDeadband(ZRotation, .02) 
+        
+        if self.robotFrontToggleCount%2 == 1:
+            XSpeed = -XSpeed
+        
        
         XSpeed = math.copysign(XSpeed * XSpeed, XSpeed)
         ZRotation = math.copysign(ZRotation * ZRotation, ZRotation)

--- a/src/subsystems/drivetrain.py
+++ b/src/subsystems/drivetrain.py
@@ -39,6 +39,13 @@ class DriveTrain(Subsystem):
         self.driveLeftMaster.setInverted(False)
         self.driveRightSlave.setInverted(True)
         self.driveRightMaster.setInverted(True)
+        
+        
+        """
+        Initializes the count for toggling which side of the 
+        robot will be considered the front when driving.
+        """
+        self.robotFrontToggleCount = 2
 
         # Configures each master to use the attached Mag Encoders
         self.driveLeftMaster.configSelectedFeedbackSensor(
@@ -51,8 +58,9 @@ class DriveTrain(Subsystem):
         self.driveLeftMaster.setSensorPhase(True)
         self.driveRightMaster.setSensorPhase(True)
 
-        self.driveLeftMaster.setQuadraturePosition(0, 0)
-        self.driveRightMaster.setQuadraturePosition(0, 0)    
+        # these supposedly aren't part of the WPI_TalonSRX class
+        # self.driveLeftMaster.setSelectedSensorPostion(0, 0, 10)
+        # self.driveRightMaster.setSelectedSensorPosition(0, 0, 10)
 
         # Throw data on the SmartDashboard so we can work with it.
         # SD.putNumber(
@@ -74,19 +82,7 @@ class DriveTrain(Subsystem):
         self.driveControllerRight.setInverted(True)
         self.drive = DifferentialDrive(self.driveControllerLeft,
                                        self.driveControllerRight)
-        # self.drive = DifferentialDrive(self.driveLeftMaster,
-        #                               self.driveRightMaster)
-        
-        wpilib.LiveWindow.addActuator("DriveTrain", "Left Master", self.driveLeftMaster)
-        wpilib.LiveWindow.addActuator("DriveTrain", "Right Master", self.driveRightMaster)
-        #wpilib.LiveWindow.add(self.driveLeftSlave)
-        #wpilib.LiveWindow.add(self.driveRightSlave)
-        #wpilib.Sendable.setName(self.drive, 'Drive')
-        #wpilib.LiveWindow.add(self.drive)
-        #wpilib.Sendable.setName(self.driveLeftMaster, 'driveLeftMaster')
-        #wpilib.LiveWindow.add(self.driveRightMaster)
-        
-        
+
         super().__init__()
 
     def moveToPosition(self, position, side='left'):
@@ -103,6 +99,28 @@ class DriveTrain(Subsystem):
     def arcade(self, speed, rotation):
         self.updateSD()
         self.drive.arcadeDrive(speed, rotation, True)
+        
+        """
+        This if statement acts as a toggle to change which motors are 
+        inverted, completely changing the "front" of the robot. This is
+        useful for when we are about to climb.
+        """
+        if self.robot.dStick.getRawButtonReleased(3) and (self.robotFrontToggleCount%2 == 0):
+            self.robotFrontToggleCount += 1
+            
+            self.driveLeftSlave.setInverted(False)
+            self.driveLeftMaster.setInverted(False)
+            self.driveRightSlave.setInverted(True)
+            self.driveRightMaster.setInverted(True)
+            
+        elif self.robot.dStick.getRawButtonReleased(3) and (self.robotFrontToggleCount%2 == 1):
+            self.robotFrontToggleCount += 1
+            
+            self.driveLeftSlave.setInverted(True)
+            self.driveLeftMaster.setInverted(True)
+            self.driveRightSlave.setInverted(False)
+            self.driveRightMaster.setInverted(False)
+            
 
     def updateSD(self):
 

--- a/src/subsystems/grabber.py
+++ b/src/subsystems/grabber.py
@@ -32,6 +32,8 @@ class Grabber(Subsystem):
         """
         self.armModeToggleCount = 2
         self.openToggleCount = 3
+        
+        super().__init__()
     
     def grabberFunction(self):
         """


### PR DESCRIPTION
Full functionality for normal arcade drive with and toggle to inverse the direction of the robot. Added driving with RPM in arcade drive, this will need a toggle to inverse direction as well, however.